### PR TITLE
Add strtoupper on method

### DIFF
--- a/src/Hitrov/OCI/Signer.php
+++ b/src/Hitrov/OCI/Signer.php
@@ -231,7 +231,7 @@ class Signer
      */
     private function shouldHashBody(string $method): bool
     {
-        return in_array($method, ['POST', 'PUT', 'PATCH']);
+        return in_array(strtoupper($method), ['POST', 'PUT', 'PATCH']);
     }
 
     /**


### PR DESCRIPTION
Hello,

I propose adding a strtoupper here as a nice to have. I'm working in a framework that has an http client that uses lower case method function names. Ran into an issue where I wasn't getting body signatures because this method is case sensitive.

Adding this will ensure it does not matter what case the user submits the method as.