### PR TITLE
standardize "method" casing

### DIFF
--- a/src/Hitrov/OCI/Signer.php
+++ b/src/Hitrov/OCI/Signer.php
@@ -231,7 +231,7 @@ class Signer
      */
     private function shouldHashBody(string $method): bool
     {
-        return in_array($method, ['POST', 'PUT', 'PATCH']);
+        return in_array(strtoupper($method), ['POST', 'PUT', 'PATCH']);
     }
 
     /**


### PR DESCRIPTION
`in_array()` is case-sensitive, so if a non-fully uppercase version of "POST", "PUT", or "PATCH" is passed in, it will fail when very likely the intended outcome is that it passes.

```php
function shouldHashBody(string $method): bool
{
    return in_array($method, ['POST', 'PUT', 'PATCH']);
}
    
var_dump(shouldHashBody('post')); //false
var_dump(shouldHashBody('POST')); //true
```